### PR TITLE
Update mono repo locations + Add python 3.6 support

### DIFF
--- a/Dockerfile-python2.7-mono4.8.0-pythonnet2.3.0
+++ b/Dockerfile-python2.7-mono4.8.0-pythonnet2.3.0
@@ -4,7 +4,7 @@ RUN apt-get update \
   && apt-get install -y curl \
   && rm -rf /var/lib/apt/lists/* \
   && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF \
-  && echo "deb http://download.mono-project.com/repo/debian wheezy main" >> /etc/apt/sources.list.d/mono-xamarin.list \
+  && echo "deb http://download.mono-project.com/repo/debian wheezy/snapshots/4.8.0.520/. main" >> /etc/apt/sources.list.d/mono-xamarin.list \
   && echo "deb http://download.mono-project.com/repo/debian wheezy-apache24-compat main" >> /etc/apt/sources.list.d/mono-xamarin.list \
   && echo "deb http://download.mono-project.com/repo/debian wheezy-libjpeg62-compat main" >> /etc/apt/sources.list.d/mono-xamarin.list \
   && apt-get update \

--- a/Dockerfile-python3.5-mono4.8.0-pythonnet2.3.0
+++ b/Dockerfile-python3.5-mono4.8.0-pythonnet2.3.0
@@ -4,7 +4,7 @@ RUN apt-get update \
   && apt-get install -y curl \
   && rm -rf /var/lib/apt/lists/* \
   && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF \
-  && echo "deb http://download.mono-project.com/repo/debian wheezy main" >> /etc/apt/sources.list.d/mono-xamarin.list \
+  && echo "deb http://download.mono-project.com/repo/debian wheezy/snapshots/4.8.0.520/. main" >> /etc/apt/sources.list.d/mono-xamarin.list \
   && echo "deb http://download.mono-project.com/repo/debian wheezy-apache24-compat main" >> /etc/apt/sources.list.d/mono-xamarin.list \
   && echo "deb http://download.mono-project.com/repo/debian wheezy-libjpeg62-compat main" >> /etc/apt/sources.list.d/mono-xamarin.list \
   && apt-get update \

--- a/Dockerfile-python3.6-mono4.8.0-pythonnet2.3.0
+++ b/Dockerfile-python3.6-mono4.8.0-pythonnet2.3.0
@@ -1,0 +1,15 @@
+FROM python:3.6
+
+RUN apt-get update \
+  && apt-get install -y curl \
+  && rm -rf /var/lib/apt/lists/* \
+  && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF \
+  && echo "deb http://download.mono-project.com/repo/debian wheezy/snapshots/4.8.0.520/. main" >> /etc/apt/sources.list.d/mono-xamarin.list \
+  && echo "deb http://download.mono-project.com/repo/debian wheezy-apache24-compat main" >> /etc/apt/sources.list.d/mono-xamarin.list \
+  && echo "deb http://download.mono-project.com/repo/debian wheezy-libjpeg62-compat main" >> /etc/apt/sources.list.d/mono-xamarin.list \
+  && apt-get update \
+  && apt-get install -y clang \
+  && apt-get install -y mono-complete=4.8.0.520-0xamarin3 \
+  && rm -rf /var/lib/apt/lists/* /tmp/*
+
+RUN pip install pycparser==2.17 && pip install pythonnet==2.3.0

--- a/build_and_deploy.sh
+++ b/build_and_deploy.sh
@@ -4,6 +4,8 @@ set -e
 
 docker build -t pythonnet/pythonnet:python2.7-mono4.8.0-pythonnet2.3.0 -f Dockerfile-python2.7-mono4.8.0-pythonnet2.3.0 .
 docker build -t pythonnet/pythonnet:python3.5-mono4.8.0-pythonnet2.3.0 -f Dockerfile-python3.5-mono4.8.0-pythonnet2.3.0 .
+docker build -t pythonnet/pythonnet:python3.6-mono4.8.0-pythonnet2.3.0 -f Dockerfile-python3.6-mono4.8.0-pythonnet2.3.0 .
 
 docker push pythonnet/pythonnet:python2.7-mono4.8.0-pythonnet2.3.0
 docker push pythonnet/pythonnet:python3.5-mono4.8.0-pythonnet2.3.0
+docker push pythonnet/pythonnet:python3.6-mono4.8.0-pythonnet2.3.0


### PR DESCRIPTION
Edit:
To give context about change of mono repo location
> I ran into an error building a docker image from the dockerfile. It indicated that '4.8.0.520-0xamarin3' for 'mono-complete' was not found. I changed it to point the Ubuntu snapshot for 4.8.0.520 and it worked. -- @fdanny #6 