### PR TITLE
Pin the version to the snapshots directory FOR 4.8

### DIFF
--- a/Dockerfile-python2.7-mono4.8.0-pythonnet2.3.0
+++ b/Dockerfile-python2.7-mono4.8.0-pythonnet2.3.0
@@ -4,7 +4,7 @@ RUN apt-get update \
   && apt-get install -y curl \
   && rm -rf /var/lib/apt/lists/* \
   && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF \
-  && echo "deb http://download.mono-project.com/repo/debian wheezy main" >> /etc/apt/sources.list.d/mono-xamarin.list \
+  && echo "deb http://download.mono-project.com/repo/ubuntu wheezy/snapshots/4.8.0.520 main" >> /etc/apt/sources.list.d/mono-xamarin.list \
   && echo "deb http://download.mono-project.com/repo/debian wheezy-apache24-compat main" >> /etc/apt/sources.list.d/mono-xamarin.list \
   && echo "deb http://download.mono-project.com/repo/debian wheezy-libjpeg62-compat main" >> /etc/apt/sources.list.d/mono-xamarin.list \
   && apt-get update \

--- a/Dockerfile-python3.5-mono4.8.0-pythonnet2.3.0
+++ b/Dockerfile-python3.5-mono4.8.0-pythonnet2.3.0
@@ -4,7 +4,7 @@ RUN apt-get update \
   && apt-get install -y curl \
   && rm -rf /var/lib/apt/lists/* \
   && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF \
-  && echo "deb http://download.mono-project.com/repo/debian wheezy main" >> /etc/apt/sources.list.d/mono-xamarin.list \
+  && echo "deb http://download.mono-project.com/repo/ubuntu wheezy/snapshots/4.8.0.520 main" >> /etc/apt/sources.list.d/mono-xamarin.list \
   && echo "deb http://download.mono-project.com/repo/debian wheezy-apache24-compat main" >> /etc/apt/sources.list.d/mono-xamarin.list \
   && echo "deb http://download.mono-project.com/repo/debian wheezy-libjpeg62-compat main" >> /etc/apt/sources.list.d/mono-xamarin.list \
   && apt-get update \


### PR DESCRIPTION
I ran into an error building a docker image from the dockerfile. It indicated that '4.8.0.520-0xamarin3' for 'mono-complete' was not found. I changed it to point the Ubuntu snapshot for 4.8.0.520 and it worked.